### PR TITLE
Improve consistency of WeightVector usage

### DIFF
--- a/logs/2016-06-15/penn2malt.txt
+++ b/logs/2016-06-15/penn2malt.txt
@@ -1,0 +1,11 @@
+Machine: cs-nll-15
+
+Branch: 8c8c5a751329ebd84c0a6db574fca16d22a6e3bc
+
+Command:
+python glm_parser.py -i 1 -s 16 -p /cs/natlang-user/vivian/penn-wsj-deps/ --train='wsj_0[2-9][0-9][0-9].mrg.3.pa.gs.tab|wsj_1[0-9][0-9][0-9].mrg.3.pa.gs.tab|wsj_2[0-1][0-9][0-9].mrg.3.pa.gs.tab' --test='wsj_0[0-1][0-9][0-9].mrg.3.pa.gs.tab|wsj_22[0-9][0-9].mrg.3.pa.gs.tab|wsj_24[0-9][0-9].mrg.3.pa.gs.tab' --learner=perceptron --fgen=english_1st_fgen --parser=ceisner --format=${project_path}/src/format/penn2malt.format
+
+Result:
+Total Training Time:  3005.1084609
+Unlabeled accuracy: 0.865941551834
+Unlabeled attachment accuracy: 0.871303458342

--- a/src/debug/interact.py
+++ b/src/debug/interact.py
@@ -253,7 +253,7 @@ def average_perceptron_learner_sequential_learn_wrapper(self, f_argmax, data_poo
                         self.last_change_dict[s] = self.c
 
                     # update weight and weight sum
-                    self.w_vector.data_dict.iadd(delta_global_vector.feature_dict)
+                    self.w_vector.iadd(delta_global_vector.feature_dict)
                     self.weight_sum_dict.iadd(delta_global_vector.feature_dict)
 
             else:
@@ -262,7 +262,7 @@ def average_perceptron_learner_sequential_learn_wrapper(self, f_argmax, data_poo
                     self.last_change_dict[s] = self.c
 
                 if not current_global_vector == gold_global_vector:
-                    self.w_vector.data_dict.iadd(delta_global_vector.feature_dict)
+                    self.w_vector.iadd(delta_global_vector.feature_dict)
                     self.weight_sum_dict.iadd(delta_global_vector.feature_dict)
 
             self.c += 1
@@ -288,7 +288,7 @@ def average_perceptron_learner_sequential_learn_wrapper(self, f_argmax, data_poo
             p_fork.start()
             # self.w_vector.dump(d_filename + "_Iter_%d.db"%t)
 
-    self.w_vector.data_dict.clear()
+    self.w_vector.clear()
 
     self.avg_weight(self.w_vector, self.c - 1)
 

--- a/src/evaluate/evaluator.py
+++ b/src/evaluate/evaluator.py
@@ -59,7 +59,7 @@ class Evaluator():
             self.unlabeled_accuracy(test_edge_set, gold_edge_set, True)
         if training_time is not None:
             logging.info("Training time usage(seconds): %f" % (training_time,))
-        logging.info("Feature count: %d" % len(w_vector.data_dict.keys()))
+        logging.info("Feature count: %d" % len(w_vector.keys()))
         logging.info("Unlabeled accuracy: %.12f (%d, %d)" % (self.get_acc_unlabeled_accuracy(), self.unlabeled_correct_num, self.unlabeled_gold_set_size))
         print "Unlabeled accuracy: %.12f" %self.get_acc_unlabeled_accuracy()
         self.unlabeled_attachment_accuracy(data_pool.get_sent_num())

--- a/src/learn/perceptron.py
+++ b/src/learn/perceptron.py
@@ -43,28 +43,28 @@ class PerceptronLearner():
 
     def update_weight(self, current_global_vector, gold_global_vector):
         # otherwise, the gold_global_vector will change because of the change in weights
-        self.w_vector.data_dict.iadd(gold_global_vector.feature_dict)
-        self.w_vector.data_dict.iaddc(current_global_vector.feature_dict, -1)
+        self.w_vector.iadd(gold_global_vector.feature_dict)
+        self.w_vector.iaddc(current_global_vector.feature_dict, -1)
         return
 
     def parallel_learn(self,dp,fv,parser):
         #dp = data_pool.DataPool(textString=textString[1],fgen=fgen,format_list=format)
         w_vector = weight_vector.WeightVector()
         for key in fv.keys():
-            w_vector.data_dict[key]=fv[key]
+            w_vector[key]=fv[key]
         #print data_pool.get_sent_num
         while dp.has_next_data():
             data_instance = dp.get_next_data()
             gold_global_vector = data_instance.convert_list_vector_to_dict(data_instance.gold_global_vector)
             current_edge_set = parser.parse(data_instance, w_vector.get_vector_score)
             current_global_vector = data_instance.set_current_global_vector(current_edge_set)
-            w_vector.data_dict.iadd(gold_global_vector.feature_dict)
-            w_vector.data_dict.iaddc(current_global_vector.feature_dict, -1)
+            w_vector.iadd(gold_global_vector.feature_dict)
+            w_vector.iaddc(current_global_vector.feature_dict, -1)
 
         dp.reset_index()
 
         vector_list = {}
-        for key in w_vector.data_dict.keys():
-            vector_list[str(key)] = w_vector.data_dict[key]
+        for key in w_vector.keys():
+            vector_list[str(key)] = w_vector[key]
 
         return vector_list.items()

--- a/src/learn/spark_train.py
+++ b/src/learn/spark_train.py
@@ -86,9 +86,9 @@ class ParallelPerceptronLearner():
                 for (feat, (a,b,c)) in feat_vec_list:
                     fv[feat] = (float(a)/float(c),b)
 
-            self.w_vector.data_dict.clear()
+            self.w_vector.clear()
             for feat in fv.keys():
-                self.w_vector.data_dict[feat] = fv[feat][1]/c
+                self.w_vector[feat] = fv[feat][1]/c
         if learner.__class__.__name__== "PerceptronLearner":
             fv = {}
             for round in range(max_iter):
@@ -104,8 +104,8 @@ class ParallelPerceptronLearner():
                 fv = {}
                 for (feat,(a,b)) in feat_vec_list:
                     fv[feat] = float(a)/float(b)
-            self.w_vector.data_dict.clear()
-            self.w_vector.data_dict.iadd(fv)
+            self.w_vector.clear()
+            self.w_vector.iadd(fv)
             #dump the weight vector
             #d_filename: change the full path to hdfs file name
             if d_filename is not None:

--- a/src/ner/ner_decode.py
+++ b/src/ner/ner_decode.py
@@ -86,7 +86,7 @@ class Decoder:
         #self.reset_weights()
         feat_vec = weight_vector.WeightVector()
         feat_vec.load(weight_file)
-        self.weight_vec = feat_vec.data_dict
+        self.weight_vec = feat_vec
 
 
 

--- a/src/ner/ner_perctrain.py
+++ b/src/ner/ner_perctrain.py
@@ -163,7 +163,7 @@ class Trainer:
 
     def dump_vector(self, filename, i, fv):
         w_vector = weight_vector.WeightVector()
-        w_vector.data_dict.iadd(fv)
+        w_vector.iadd(fv)
         w_vector.dump(filename + "_Iter_%d.db"%i)
 
 def main(training_file):

--- a/src/pos/pos_perctrain.py
+++ b/src/pos/pos_perctrain.py
@@ -102,7 +102,7 @@ class PosPerceptron():
 
     def dump_vector(self, filename, i, fv):
         w_vector = weight_vector.WeightVector()
-        w_vector.data_dict.iadd(fv)
+        w_vector.iadd(fv)
         w_vector.dump(filename + "_Iter_%d.db"%i)
 
     def dump_vector_per_iter(self, filename, i, weight_vec, last_iter, avg_vec, num_updates):
@@ -116,7 +116,7 @@ class PosPerceptron():
             fv[feat] = av[feat] / num_updates
 
         w_vector = weight_vector.WeightVector()
-        w_vector.data_dict.iadd(fv)
+        w_vector.iadd(fv)
         i=i+1
         w_vector.dump(filename + "_Iter_%d.db"%i)
 """

--- a/src/pos_tagger.py
+++ b/src/pos_tagger.py
@@ -60,7 +60,7 @@ class PosTagger():
         if fv_path is not None:
             feat_vec = weight_vector.WeightVector()
             feat_vec.load(fv_path)
-            self.w_vector = feat_vec.data_dict
+            self.w_vector = feat_vec
 
         acc = tester.get_accuracy(self.w_vector)
 HELP_MSG =\

--- a/src/weight/weight_vector.py
+++ b/src/weight/weight_vector.py
@@ -17,7 +17,8 @@ logging.basicConfig(filename='glm_parser.log',
                     format='%(asctime)s %(levelname)s: %(message)s',
                     datefmt='%m/%d/%Y %I:%M:%S %p')
 
-class WeightVector():
+
+class WeightVector(mydefaultdict):
     """
     A dictitionary-like object. Used to facilitate class FeatureSet to
     store the features.
@@ -50,28 +51,15 @@ class WeightVector():
         a file name here in order to establish the connection to the database.
         :type filename: str
         """
+        super(WeightVector, self).__init__(mydouble)
 
-        # change to hvector
-        #self.data_dict = {}
-        self.data_dict = mydefaultdict(mydouble)
-
-        if not filename == None:
+        if filename is not None:
             self.load(filename)
 
-        return
-
-    #def get_sub_vector(self, key_list):
-        # TODO figure out a more efficient way
-    #    sub_vector = mydefaultdict(mydouble)
-    #    for k in key_list:
-    #        sub_vector[k] = self.data_dict[k]
-    #    return sub_vector
-
     def get_vector_score(self, fv):
-        score = self.data_dict.evaluate(fv)
-        return score
+        return self.evaluate(fv)
 
-    def load(self,filename):
+    def load(self, filename):
         """
         Load the dumped memory dictionary Pickle file into memory. Essentially
         you can do this with a shelve object, however it does not have effect,
@@ -80,52 +68,23 @@ class WeightVector():
         Parameter is the same as constructor (__init__).
         """
         logging.debug("Loading Weight Vector from %s " % filename)
-        fp = open(filename,"r")
-        for line in fp:
-            line = line[:-1]
-            line = line.split("    ")
-            self.data_dict[line[0]] = float(line[1])
-        #print self.data_dict
-        #self.data_dict = pickle.load(fp)
-        fp.close()
-        return
+        with open(filename) as f:
+            for line in f:
+                line = line[:-1].split("    ")
+                self[line[0]] = float(line[1])
 
-    def __getitem__(self,index):
-        return self.data_dict[index]
-
-    def __setitem__(self,index,value):
-        self.data_dict[index] = value
-        return
-
-    def has_key(self,index):
-        return self.data_dict.has_key(index)
-
-    def pop(self,key):
-        self.data_dict.pop(key)
-        return
-
-    def keys(self):
-        """
-        Return a list of dictionary keys. This operation is not as expensive
-        as the shelve keys() method, so we separate them.
-        """
-        return self.data_dict.keys()
-
-    def dump(self,filename):
+    def dump(self, filename):
         """
         Called when memory dictionary is used. Dump the content of the dict
         into a disk file using Pickle
         """
-        if filename == None:
+        if filename is None:
             print "Skipping dump ..."
             return
 
         logging.debug("Dumping Weight Vector to %s " % filename)
-        logging.debug("Total Feature Num: %d " % len(self.data_dict))
-        fp = open(filename,"w")
-        for key in self.data_dict.keys():
-            fp.write(str(key) + "    " + str(self.data_dict[key]) + "\n")
-        #pickle.dump(self.data_dict,fp,-1)
-        fp.close()
-        return
+        logging.debug("Total Feature Num: %d " % len(self))
 
+        with open(filename, "w") as f:
+            for k, v in self.iteritems():
+                f.write(str(k) + "    " + str(v) + "\n")


### PR DESCRIPTION
Since all that WeightVector is doing is holding a hvector defaultdict instance as an attribute and wrapping some of the `__methods__`, it should be a subclass of defaultdict. This change also allows it to be used as a defaultdict instead of other pieces of code accessing its `.data_dict` attribute directly (which sort of defeated the point of having the wrapper class).

This changes the interface of the WeightVector class, and I've fixed all the places where `.data_dict` was accessed directly, but if anyone's working on code that accesses `.data_dict`, remove that access and just use `w_vector` instead.