### PR TITLE
pos_tagger only try top 10 tags of the previous word

### DIFF
--- a/src/pos/pos_decode.py
+++ b/src/pos/pos_decode.py
@@ -39,5 +39,5 @@ class Decoder():
             correct_num += cnum
             gold_set_size += gnum
         acc = float(correct_num) / gold_set_size
-        logger.info("Total Accraccy: ", acc)
+        logger.info("Total Accraccy: %f" % acc)
         return acc

--- a/src/pos/pos_perctrain.py
+++ b/src/pos/pos_perctrain.py
@@ -100,7 +100,8 @@ class PosPerceptron():
 
                             last_iter[i] = c
 
-            logger.info("Iteration completed, number of mistakes:", log_miss)
+            logger.info("Iteration completed, number of mistakes: %d"
+                        % log_miss)
         logger.debug("Finalising")
         for i in w_vec:
             if i in last_iter:
@@ -113,8 +114,8 @@ class PosPerceptron():
         return w_vec
 
     def dump_vector(self, filename, iteration, fv):
-        logger.info("Dumping weight_vec to ", filename,
-                    "_Iter_%d.db" % iteration)
+        logger.info("Dumping weight_vec to %s_Iter_%d.db"
+                    % (filename, iteration))
         w_vector = weight_vector.WeightVector()
         w_vector.iadd(fv)
         w_vector.dump("file://" + filename + "_Iter_%d.db" % iteration)

--- a/src/pos/pos_viterbi.py
+++ b/src/pos/pos_viterbi.py
@@ -57,9 +57,13 @@ class Viterbi():
         for i in range(2, N-2):
             word = labeled_list[i]
             found_tag = False
+
+            last_viterbi = viterbi[i-1].items()
+            last_viterbi.sort(key=lambda x:x[1][0], reverse=True)
+            logger.debug(last_viterbi[0: 5])
             for tag in tagset:
                 prev_list = []
-                for prev_tag in viterbi[i-1]:
+                for (prev_tag, val) in last_viterbi[0: 10]:
                     feats = []
                     (prev_value, prev_backpointer) = viterbi[i-1][prev_tag]
                     pos_feat.get_pos_feature(feats,
@@ -80,6 +84,9 @@ class Viterbi():
                 if best_weight != 0.0:
                     viterbi[i][tag] = (best_weight, backpointer)
                     found_tag = True
+
+            # logger.debug(viterbi[i])
+
             if found_tag is False:
                 viterbi[i][default_tag] = (0.0, default_tag)
 

--- a/src/pos_tagger.py
+++ b/src/pos_tagger.py
@@ -229,7 +229,7 @@ if __name__ == '__main__':
                           max_iter = config['iterations'])
         end_time = time.time()
         training_time = end_time - start_time
-        __logger.info("Total Training Time: ", training_time)
+        __logger.info("Total Training Time: %f" % training_time)
 
     if config['test']:
         testDataPool = DataPool(section_regex = config['test'],


### PR DESCRIPTION
### Pruning added to Viterbi algorithm for pos_tagger.
#### Without pruning: 
```
try each tag in tagset for current word i:
    score the current word with each possible tag for the word i-1
    keep the highest one
```
Time Usage: about 48 hrs for penn2malt whole dataset with 5 iterations
Accuracy: 96.97%

#### With pruning:
```
try each tag in tagset for current word i:
    score the current word with the top 10 possible tags for the word i-1
    keep the highest one
```
Time Usage: about 10 hrs for penn2malt whole dataset with 5 iterations
Accuracy: 97.14%