### PR TITLE
Increment sentence_count when logging is disabled

### DIFF
--- a/src/learner/average_perceptron.py
+++ b/src/learner/average_perceptron.py
@@ -43,7 +43,7 @@ class Learner(PerceptronLearnerBase):
                             sentence_count,
                             data_pool.get_sent_num(),
                             len(data_instance.get_word_list()) - 1))
-                sentence_count += 1
+            sentence_count += 1
             gold_global_vector = data_instance.convert_list_vector_to_dict(data_instance.gold_global_vector)
             current_global_vector = f_argmax(w_vector, data_instance)
 

--- a/src/learner/perceptron.py
+++ b/src/learner/perceptron.py
@@ -40,7 +40,7 @@ class Learner(PerceptronLearnerBase):
                             sentence_count,
                             data_pool.get_sent_num(),
                             len(data_instance.get_word_list()) - 1))
-                sentence_count += 1
+            sentence_count += 1
             gold_global_vector = data_instance.convert_list_vector_to_dict(data_instance.gold_global_vector)
             current_global_vector = f_argmax(w_vector, data_instance)
 


### PR DESCRIPTION
Previously, if `log` was False, the sentence count wouldn't be
incremented, and the perceptrons wouldn't work. Now, the incrementing
is moved outside the `if log:`.